### PR TITLE
Level Browser History + fix

### DIFF
--- a/website/src/components/LevelBrowser.vue
+++ b/website/src/components/LevelBrowser.vue
@@ -35,7 +35,6 @@ export default {
       isLoading: false
     }
   },
-
   computed: {
     ...mapState(useUserStore, ['isAdmin']),
     ...mapState(useUserStore, ['isModerator']),
@@ -100,6 +99,15 @@ export default {
 
     loaded() {
       this.isLoading = false;
+    }
+  },
+  watch: {
+    '$route.query': {
+      handler(newQuery) {
+        this.tabActive = newQuery.tab || 'tab_newest'
+        this.searchTerm = newQuery.search || ''
+        this.userID = newQuery.user_id || null
+      },
     }
   }
 }


### PR DESCRIPTION
- level browser detects when you hit the back arrow now
- when switching between levels and player, the search no longer keeps the text :D (finally fixed lol) 